### PR TITLE
Fix missing information to generate the tables

### DIFF
--- a/fir/config/production.py.sample
+++ b/fir/config/production.py.sample
@@ -2,6 +2,11 @@
 # All settings that do not change across environments should be in 'fir.settings.base'
 from fir.config.base import *
 
+from environs import Env
+
+env = Env()
+env.read_env(env.str('ENV_PATH', '.env'), recurse=False)
+
 ################################################################
 ##### Change these values
 ################################################################
@@ -75,3 +80,9 @@ LOGGING = {
 
 # External URL of your FIR application (used in fir_notification to render full URIs in templates)
 EXTERNAL_URL = 'http://fir.example.com'
+
+# Show incident IDs in views?
+INCIDENT_SHOW_ID = env.bool('INCIDENT_SHOW_ID', default=False)
+
+# Incident ID prefix in views and links
+INCIDENT_ID_PREFIX = env('INCIDENT_ID_PREFIX', "FIR-")


### PR DESCRIPTION
Sample configuration is missing elements INCIDENT_ID_PREFIX 

This generate an error when launching the command 

$ ./manage.py migrate --settings fir.config.production